### PR TITLE
Remove unnecessary syntax entry for "

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -73,9 +73,6 @@
 
 (defconst ponylang-mode-syntax-table
   (let ((table (make-syntax-table)))
-    ;; " is a string delimiter too
-    (modify-syntax-entry ?\" "\"" table)
-
     ;; / is punctuation, but // is a comment starter
     (modify-syntax-entry ?/ ". 12" table)
 


### PR DESCRIPTION
This is already provided by the inherited syntax table.