### PR TITLE
Add support for struct

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -116,6 +116,7 @@
     "object"
     "primitive"
     "recover" "repeat" "return"
+    "struct"
     "then" "this" "trait" "try" "type"
     "until" "use"
     "var"
@@ -132,7 +133,7 @@
     "match"
     "new"
     "primitive"
-    "recover" "ref" "repeat"
+    "recover" "ref" "repeat" "struct"
     "tag" "then" "trait" "try"
     "until"
     "while")
@@ -220,6 +221,9 @@ the current context."
       (setq cur-indent 0))
 
      ((looking-at "^[[:space:]]*primitive\\([[:space:]].*\\)?$")
+      (setq cur-indent 0))
+
+     ((looking-at "^[[:space:]]*struct\\([[:space:]].*\\)?$")
       (setq cur-indent 0))
 
      ((looking-at "^[[:space:]]*trait\\([[:space:]].*\\)?$")


### PR DESCRIPTION
This adds support for the ``struct`` keyword:
```pony
struct MaybePointer[A]
  """
  A MaybePointer[A] is used to encode a possibly-null type. It should
  _only_ be used for structs that need to be passed to and from the C FFI.

  An optional type for anything that isn't a struct should be encoded as a
  union type, for example (A | None).
  """
  ...
```