### PR TITLE
Add "with" to indenting keywords

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -137,7 +137,7 @@
     "struct"
     "tag" "then" "trait" "try"
     "until"
-    "while")
+    "while" "with")
   "Pony keywords which indicate a new indentation level.")
 
 (defconst ponylang-constants


### PR DESCRIPTION
It seems to me that `with` is also an indenting keyword, judging by the examples.