### PR TITLE
FIX Matching quotes

### DIFF
--- a/ponylang-mode.el
+++ b/ponylang-mode.el
@@ -74,7 +74,6 @@
 (defconst ponylang-mode-syntax-table
   (let ((table (make-syntax-table)))
     ;; fontify " using ponylang-keywords
-    (modify-syntax-entry ?\" "w" table)
 
     ;; / is punctuation, but // is a comment starter
     (modify-syntax-entry ?/ ". 124" table)
@@ -195,7 +194,6 @@
     (,ponylang-keywords-regexp . font-lock-keyword-face)
 
     ("\'\\\\?.\'" . font-lock-string-face)
-    ("\\\".*\\\"" . font-lock-string-face)
 
     ;; note: order above matters. “ponylang-keywords-regexp” goes last because
     ;; otherwise the keyword “state” in the function “state_entry”


### PR DESCRIPTION
Given multiple string literals in a line, the mode would see it as one big
string literal, for example:

foo("bar") = "baz"

Would see one string literal on that line: "bar ..... baz".

I've mostly just looked around at how I think this is suppose to work in emacs
mode so this solution could be wrong however it has the expected outcome in the
few files I looked at that I saw as being broken previously.

I'm not entirely sure, but this might relate to issue #10 